### PR TITLE
Use unittest2 for Python <2.7

### DIFF
--- a/ObjectPathPy/core/parser.py
+++ b/ObjectPathPy/core/parser.py
@@ -323,8 +323,6 @@ type_map={
 
 # python tokenizer
 def tokenize_python(program):
-	if type(program) is unicode:
-		program = program.encode('utf8')
 	for t in tokenizer.generate_tokens(StringIO(program).next):
 		try:
 			#change this to output python values in correct type
@@ -377,7 +375,7 @@ def expression(rbp=0):
 	return left
 
 def parse(expr):
-	if type(expr) not in STR_TYPES:
+	if type(expr) is not str:
 		return expr
 	expr=expr.strip()
 	if not len(expr):


### PR DESCRIPTION
Sorry about the noise - made a mess of my git repository!  Reverted commits were intended for different pull request.

This allows the tests to run unchanged on Python 2.6 specifically.

Not sure what Python versions you're targeting but this seems like a quick fix to bring at least 2.6 into the fold (all tests pass on 2.6.5 - I haven't tested others)
