### PR TITLE
Python 3-compatible checking for unicode

### DIFF
--- a/ObjectPathPy/objectpath/shell.py
+++ b/ObjectPathPy/objectpath/shell.py
@@ -91,6 +91,14 @@ def printJSON(o):
 	currDepth[0]=0
 	return "".join(ret)
 
+try:
+	isinstance("", unicode)
+	def isunicode(s):
+		return isinstance(s, unicode)
+except NameError:
+	def isunicode(s):
+		return isinstance(s, str)
+
 def main():
 	parser=argparse.ArgumentParser(description='Command line options')
 	#parser.add_argument('-o', '--file', dest='file', help='File containing JSON document.')
@@ -146,7 +154,7 @@ def main():
 						r=tree.execute(input(">>> "))
 				else:
 						r=tree.execute(raw_input(">>> "))
-				if type(r) is unicode:
+				if isunicode(r):
 					r=r.encode("utf8")
 				print(printJSON(r))
 			except Exception as e:


### PR DESCRIPTION
This patch adds support for Python 3 to the ObjectPath shell by detecting what string type the current Python version uses.
