### PR TITLE
Remove dependency on pandoc when running setup.py

### DIFF
--- a/ObjectPathPy/setup.py
+++ b/ObjectPathPy/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 	pandoc = None
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+	return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
 def md2re(s):
 	if pandoc is None:
@@ -17,11 +17,11 @@ def md2re(s):
 	return doc.rst
 
 long_description = (
-    md2re(read('../README.md'))
-    + '\n' +
-    'Download\n'
-    '********\n'
-    )
+	md2re(read('../README.md'))
+	+ '\n' +
+	'Download\n'
+	'********\n'
+	)
 
 print long_description
 


### PR DESCRIPTION
fix issue #15 where installation of ObjectPath fails unless pandoc is installed which is undesirable as pandoc has lots of dependencies including non-python dependencies. Note I didn't test running with pandoc installed.
