### PR TITLE
Quiet pytz

### DIFF
--- a/objectpath/shell.py
+++ b/objectpath/shell.py
@@ -85,7 +85,7 @@ def main():
 			sortby = 'cumulative'
 			ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
 			ps.print_stats()
-			print s.getvalue()
+			print (s.getvalue())
 		return
 
 	try:
@@ -112,7 +112,7 @@ def main():
 				print(printJSON(r,length=limitResult))
 				if args.profile:
 					h = hpy()
-					print h.heap()
+					print (h.heap())
 			except Exception as e:
 				print(e)
 	except KeyboardInterrupt:

--- a/objectpath/utils/timeutils.py
+++ b/objectpath/utils/timeutils.py
@@ -11,7 +11,8 @@ try:
 		"UTC":pytz.utc
 	}
 except ImportError:
-	print("WARNING! pytz is not installed. Localized times are not supported.")
+	if os.isatty(sys.stdin.fileno()) and sys.stdout.isatty():
+		print("WARNING! pytz is not installed. Localized times are not supported.")
 
 HOURS_IN_DAY=24
 


### PR DESCRIPTION
If there is no pytz, then it will spew out errors into everything.
With this patch, it won't complain, unless running in the interactive interpreter, or like ./script.py, but not if the source or output is not a tty (e.g.: echo "string" | ./script.py, ./script.py | grep -e "".)