### PR TITLE
It will only complain about missing pytz when running in interactive.

### DIFF
--- a/objectpath/utils/timeutils.py
+++ b/objectpath/utils/timeutils.py
@@ -5,13 +5,15 @@
 # Copyright (C) 2008-2010 Adrian Kalbarczyk
 
 import datetime
+import sys, os
 try:
 	import pytz
 	TIMEZONE_CACHE={
 		"UTC":pytz.utc
 	}
 except ImportError:
-	print("WARNING! pytz is not installed. Localized times are not supported.")
+	if os.isatty(sys.stdin.fileno()) and sys.stdout.isatty():
+		print("WARNING! pytz is not installed. Localized times are not supported.")
 
 HOURS_IN_DAY=24
 


### PR DESCRIPTION
Without this commit, the objectpath would print into _everything_ if it couldn't import the pytz.
Now, it will only complain if the stdin is not a file and the stdout is a tty - so you will get an error if you open up the interactive interpreter, or when you run a script as ./script.py, but not if you echo "string" | ./script.py or ./script.py | egrep -e "regex".
The earlier pull was mistakenly about two commits instead of only this one - the other one is in another pull request already.