### PR TITLE
Added `values` function

### DIFF
--- a/objectpath/core/interpreter.py
+++ b/objectpath/core/interpreter.py
@@ -557,7 +557,7 @@ class Tree(Debugger):
 					except TypeError:
 						return args
 				elif fnName=="map":
-					return map(lambda x: exe(("fn",args[0],x)), args[1])
+					return chain(*map(lambda x: exe(("fn",args[0],x)), args[1]))
 				elif fnName in ("count","len"):
 					args=args[0]
 					if args in (True,False,None):

--- a/objectpath/core/interpreter.py
+++ b/objectpath/core/interpreter.py
@@ -619,6 +619,11 @@ class Tree(Debugger):
 						return list(args[0].keys())
 					except AttributeError:
 						raise ExecutionError("Argument is not "+color.bold("object")+" but %s in keys()"%color.bold(type(args[0]).__name__))
+				elif fnName=="values":
+					try:
+						return list(args[0].values())
+					except AttributeError:
+						raise ExecutionError("Argument is not "+color.bold("object")+" but %s in values()"%color.bold(type(args[0]).__name__))
 				elif fnName=="type":
 					ret=type(args[0])
 					if ret in ITER_TYPES:

--- a/tests/test_ObjectPath.py
+++ b/tests/test_ObjectPath.py
@@ -86,9 +86,26 @@ object3={
 	}
 }
 
+object4={
+	"root": {
+		"response": {
+			"200": {
+				"value": 5,
+			},
+			"201": {
+				"value": 4,
+			},
+			"404": {
+				"value": 0,
+			}
+		}
+	}
+}
+
 tree1=Tree(object1)
 tree2=Tree(object2)
 tree3=Tree(object3)
+tree4=Tree(object4)
 
 def execute_raw(expr):
 	return tree1.execute(expr)
@@ -114,6 +131,13 @@ def execute2(expr):
 
 def execute3(expr):
 	r=tree3.execute(expr)
+	if isinstance(r, TYPES):
+		return list(r)
+	else:
+		return r
+
+def execute4(expr):
+	r=tree4.execute(expr)
 	if isinstance(r, TYPES):
 		return list(r)
 	else:
@@ -455,10 +479,9 @@ class ObjectPath_Paths(unittest.TestCase):
 		self.assertEqual(execute3("$..*[@.x is 5.6 and @.y is 9.891].value"), ['bar'])
 
 	def test_object_list(self):
-		self.assertEqual(
-			execute3('values($.*).value'),
-			[ 'foo', 'bar', 'foobar' ]
-		)
+		self.assertEqual(execute3('values($.*).value'), [ 'foo', 'bar', 'foobar' ])
+		self.assertEqual(execute3('keys($.*)'), [ 'item_1', 'item_2', 'item_3' ])
+		self.assertEqual(execute4('map(values, $..root..response).value'), [ 5, 4, 0 ])
 
 #testcase2=unittest.FunctionTestCase(test_efficiency(2))
 testcase1=unittest.TestLoader().loadTestsFromTestCase(ObjectPath)

--- a/tests/test_ObjectPath.py
+++ b/tests/test_ObjectPath.py
@@ -454,6 +454,12 @@ class ObjectPath_Paths(unittest.TestCase):
 		self.assertEqual(sorted(execute2("$.store.book[@.price]")), sorted([8.95,12.99,8.99,22.99]))
 		self.assertEqual(execute3("$..*[@.x is 5.6 and @.y is 9.891].value"), ['bar'])
 
+	def test_object_list(self):
+		self.assertEqual(
+			execute3('values($.*).value'),
+			[ 'foo', 'bar', 'foobar' ]
+		)
+
 #testcase2=unittest.FunctionTestCase(test_efficiency(2))
 testcase1=unittest.TestLoader().loadTestsFromTestCase(ObjectPath)
 testcase2=unittest.TestLoader().loadTestsFromTestCase(ObjectPath_Paths)


### PR DESCRIPTION
Our structure uses a dictionary instead of a list but we only know about the values, not the keys. I was originally considering overriding `*` to also work with dictionaries (defaulting to converting them to values), but found that just adding a `values` function offered less ambiguous functionality.

A test was added demonstrating how this might be useful. We are crawling OpenAPI specifications and this is a situation which arrises.