### PR TITLE
Add missing "os" import in shell.py

### DIFF
--- a/objectpath/shell.py
+++ b/objectpath/shell.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2010-2014 Adrian Kalbarczyk
 
 import argparse
+import os
 import sys
 try:
   import readline


### PR DESCRIPTION
If pytz is not installed, the call to os.isatty raises an exception because os is never imported. This PR adds the os package to the imports.