### PR TITLE
Use chain.from_iterable in interpreter.py

### DIFF
--- a/objectpath/core/interpreter.py
+++ b/objectpath/core/interpreter.py
@@ -385,11 +385,9 @@ class Tree(Debugger):
           if D: self.debug(color.op("..") + " returning %s", color.bold(ret))
           return ret
         else:
-          ret = chain(
-              *(
-                  type(x) in ITER_TYPES and x or [x]
-                  for x in (e[snd] for e in fst if snd in e)
-              )
+          ret = chain.from_iterable(
+              type(x) in ITER_TYPES and x or [x]
+              for x in (e[snd] for e in fst if snd in e)
           )
           # print list(chain(*(type(x) in ITER_TYPES and x or [x] for x in (e[snd] for e in fst if snd in e))))
           if D: self.debug(color.op("..") + " returning %s", color.bold(self.cleanOutput(ret)))
@@ -656,7 +654,7 @@ class Tree(Debugger):
           except TypeError:
             return args[0]
         elif fnName == "map":
-          return chain(*map(lambda x: exe(("fn", args[0], x)), args[1]))
+          return chain.from_iterable(map(lambda x: exe(("fn", args[0], x)), args[1]))
         elif fnName in ("count", "len"):
           args = args[0]
           if args in (True, False, None):


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.